### PR TITLE
fix(component): initialize component in AfterViewInit instead of OnInit

### DIFF
--- a/src/powerbi-component.component.ts
+++ b/src/powerbi-component.component.ts
@@ -1,7 +1,7 @@
 import {
   Component,
-  OnInit,
   OnChanges,
+  AfterViewInit,
   SimpleChanges,
   Input,
   Inject,
@@ -16,7 +16,7 @@ import { service as PBIService, IEmbedConfiguration, Embed, models } from 'power
   selector: 'powerbi-component',
   template: '<div style="height:100%; width: 100%;" class="powerbi-frame" #powerbiFrame></div>',
 })
-export class PowerBIComponentComponent implements OnInit, OnChanges {
+export class PowerBIComponentComponent implements AfterViewInit, OnChanges {
   component: Embed;
   @Input() accessToken: string;
   @Input() tokenType: string;
@@ -30,7 +30,7 @@ export class PowerBIComponentComponent implements OnInit, OnChanges {
   constructor( @Inject('PowerBIService') public powerBIService: PBIService.Service) {
   }
 
-  ngOnInit(): void {
+  ngAfterViewInit(): void {
     const { accessToken, tokenType, embedUrl, type, id } = this;
 
     let config: IEmbedConfiguration = { accessToken, tokenType: this.getTokenType(tokenType), embedUrl, type, id };


### PR DESCRIPTION
Some backstory to this PR:

We're using this component inside a `mat-tab-group` from [angular material](https://github.com/angular/material2) as such:
```html
<mat-tab-group *ngIf="embedUrl && org._id === selectedAccount?._id">
    <mat-tab label="Some label">
          <div class="power-bi-wrapper">
            <powerbi-component [embedUrl]="url"
                               [accessToken]="token"
                               type="report"
                               [id]="reportId"
            ></powerbi-component>
          </div>
    </mat-tab>

    <mat-tab label="Some other label" *ngIf="otherReportId && otherUrl">
          <div class="power-bi-wrapper">
            <powerbi-component [embedUrl]="otherUrl"
                               [accessToken]="otherToken"
                               type="report"
                               [id]="otherReportId"
            ></powerbi-component>
          </div>
    </mat-tab>
  </mat-tab-group>
```

However, when the page is loaded and the power BI library tries to add stuff to the iframe, it seems as though the iframe has not been added to the page yet. You can see in the screenshot below that the `contentWindow` of the iframe is undefined, [which means that it hasn't beeen added to the DOM yet](https://stackoverflow.com/a/12200054/5524550).

![Imgur](https://i.imgur.com/FbR0m3j.png)

And the following error is thrown:
![Imgur](https://i.imgur.com/TXevY3w.png)
By waiting until `AfterViewInit` we should be able to be sure that the iframe has been added to the page before loading data.

This only happens on page load, so if we open a sidepane or something, the iframe is loaded properly.

I haven't been able to test if this PR actually works, as I can't seem to get my fork up and running with our project. Any advice on this is welcome.