### PR TITLE
fix(component): dont call embed on first change.

### DIFF
--- a/src/powerbi-component.component.ts
+++ b/src/powerbi-component.component.ts
@@ -43,6 +43,10 @@ export class PowerBIComponentComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     const { accessToken, tokenType, embedUrl, type, id } = changes;
 
+    if (accessToken.isFirstChange() && embedUrl.isFirstChange()) {
+      return;
+    }
+
     if (accessToken.previousValue === accessToken.currentValue
       || embedUrl.previousValue === embedUrl.currentValue) {
       return;


### PR DESCRIPTION
The embed() function is called twice in rapid succession on loading the component, once in onChanges, and once in ngOnInit. The second of which tries to load data into the existing frame which in some situations hasn't been inserted into the dom yet.

To avoid this behavior, this PR simply returns in the first onChanges call.

Please see stackblitz: [app](https://angular-7njwul-w4tlgq.stackblitz.io/) and [source](https://stackblitz.com/edit/angular-7njwul-w4tlgq)

This is the error message thrown:
![error message](https://camo.githubusercontent.com/0cd09e827e2b35f7011e3ef3868ebcbecf031640/68747470733a2f2f692e696d6775722e636f6d2f545865765933772e706e67)

